### PR TITLE
Support for port/address cli parameter

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -9,25 +9,54 @@ const ephemeral = !process.argv.includes('--non-ephemeral')
 const idFile = path.join(os.tmpdir(), 'dht-rpc-id')
 if (!fs.existsSync(idFile)) fs.writeFileSync(idFile, dhtrpc.id())
 const id = fs.readFileSync(idFile).slice(0, 32)
-const dht = require('./')({ ephemeral, adaptive: ephemeral, id })
 
-console.log('node id: ' + dht.id.toString('hex'))
 const quiet = process.argv.includes('--quiet')
 
-dht.on('ready', function () {
-  console.log('dht node fully bootstrapped')
-})
+const portRegex = /^(--port|-p)=(\d{1,5})$/
+const portArg = process.argv.find(arg => portRegex.test(arg))
+if (portArg) {
+  const port = parseInt(portRegex.exec(portArg)[2], 10)
+  const addrRegex = /^(--address|-a)=(.+)$/
+  const addrArg = process.argv.find(arg => addrRegex.test(arg))
+  const addr = addrArg ? addrArg[2] : null
+  const socket = require('dgram').createSocket('udp4')
 
-if (!quiet) {
-  dht.on('announce', function (target, peer) {
-    console.log('received announce', target, peer)
+  socket.on('error', function (err) {
+    console.log(`server error:\n${err.stack}`)
+    socket.close()
+    process.exit(1)
   })
 
-  dht.on('unannounce', function (target, peer) {
-    console.log('received unannounce', target, peer)
+  socket.on('listening', function () {
+    const address = socket.address()
+    console.log(`listening on socket: ${address.address}:${address.port}`)
+    start(socket)
   })
 
-  dht.on('lookup', function (target, peer) {
-    console.log('received lookup', target, peer)
+  socket.bind(port, addr)
+} else {
+  start()
+}
+
+function start (socket) {
+  const dht = require('./')({ ephemeral, adaptive: ephemeral, id, socket })
+  console.log('node id: ' + dht.id.toString('hex'))
+
+  dht.on('ready', function () {
+    console.log('dht node fully bootstrapped')
   })
+
+  if (!quiet) {
+    dht.on('announce', function (target, peer) {
+      console.log('received announce', target, peer)
+    })
+
+    dht.on('unannounce', function (target, peer) {
+      console.log('received unannounce', target, peer)
+    })
+
+    dht.on('lookup', function (target, peer) {
+      console.log('received lookup', target, peer)
+    })
+  }
 }


### PR DESCRIPTION
To listen to a concrete address and port before the bootstrap operation we need to connect to a socket before starting the dht.

Closes #11 