### PR TITLE
Line re-ordering to fix temporal dead zone error

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,12 @@ module.exports = class HyperDHT extends DHT {
 
     const localPayload = holepunch.bind()
     const socket = holepunch.socket
+    
+    const value = cenc.encode(messages.connect, { noise: noise.send(localPayload), relayAuth: localPayload.relayAuth })
+    const query = this.query(target, 'connect', value, { socket, nodes: opts.nodes, map: mapConnect })
+
+    let error = null
+    
     const timeout = setTimeout(ontimeout, CLIENT_TIMEOUT)
 
     // forward incoming messages to the dht
@@ -141,11 +147,6 @@ module.exports = class HyperDHT extends DHT {
     localPayload.relayAuth = Buffer.allocUnsafe(32)
 
     sodium.randombytes_buf(localPayload.relayAuth)
-
-    const value = cenc.encode(messages.connect, { noise: noise.send(localPayload), relayAuth: localPayload.relayAuth })
-    const query = this.query(target, 'connect', value, { socket, nodes: opts.nodes, map: mapConnect })
-
-    let error = null
 
     for await (const { from, token, connect } of query) {
       const payload = noise.recv(connect.noise, false)


### PR DESCRIPTION
Definition of `value` and `error` in `connectRaw(publicKey, opts = {})` must be before reference to `ontimeout`.

Else a  "temporal dead zone error" might occur:
https://stackoverflow.com/a/62203661

See issue 44:

 hyperswarm#44