### PR TITLE
Add `sign` option to APIs that require signing

### DIFF
--- a/lib/persistent.js
+++ b/lib/persistent.js
@@ -220,28 +220,24 @@ module.exports = class Persistent {
     req.reply(null)
   }
 
-  static signMutable (seq, value, secretKey) {
-    const signature = Buffer.allocUnsafe(64)
+  static signMutable (seq, value, secretKeyOrSigner) {
     const signable = Buffer.allocUnsafe(32)
     sodium.crypto_generichash(signable, c.encode(m.mutableSignable, { seq, value }), NS.MUTABLE_PUT)
-    sodium.crypto_sign_detached(signature, signable, secretKey)
-    return signature
+    return sign(signable, secretKeyOrSigner)
   }
 
   static verifyMutable (signature, seq, value, publicKey) {
     return verifyMutable(signature, seq, value, publicKey)
   }
 
-  static signAnnounce (target, token, id, ann, secretKey) {
-    const signature = Buffer.allocUnsafe(64)
-    sodium.crypto_sign_detached(signature, annSignable(target, token, id, ann, NS.ANNOUNCE), secretKey)
-    return signature
+  static signAnnounce (target, token, id, ann, secretKeyOrSigner) {
+    const signable = annSignable(target, token, id, ann, NS.ANNOUNCE)
+    return sign(signable, secretKeyOrSigner)
   }
 
-  static signUnannounce (target, token, id, ann, secretKey) {
-    const signature = Buffer.allocUnsafe(64)
-    sodium.crypto_sign_detached(signature, annSignable(target, token, id, ann, NS.UNANNOUNCE), secretKey)
-    return signature
+  static signUnannounce (target, token, id, ann, secretKeyOrSigner) {
+    const signable = annSignable(target, token, id, ann, NS.UNANNOUNCE)
+    return sign(signable, secretKeyOrSigner)
   }
 }
 
@@ -271,4 +267,11 @@ function decode (enc, val) {
   } catch (err) {
     return null
   }
+}
+
+function sign (signable, secretKeyOrSigner) {
+  if (typeof secretKeyOrSigner === 'function') return secretKeyOrSigner(signable)
+  const signature = Buffer.allocUnsafe(64)
+  sodium.crypto_sign_detached(signature, signable, secretKeyOrSigner)
+  return signature
 }


### PR DESCRIPTION
This pull request introduces a new `sign` option to APIs that require signing, such as `node.announce()` and `node.mutablePut()`. If given, this property is expected to be an optionally async function that signs the given buffer.

It still lacks tests and docs as I wanted to get some input on the API first.