### PR TITLE
Support externally managed secret keys

### DIFF
--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -6,13 +6,13 @@ const Persistent = require('./persistent')
 const { COMMANDS } = require('./constants')
 
 module.exports = class Announcer {
-  constructor (dht, keyPair, target) {
+  constructor (dht, keyPair, target, record) {
     this.dht = dht
     this.keyPair = keyPair
     this.target = target
     this.relays = []
     this.stopped = false
-    this.record = c.encode(m.peer, { publicKey: this.keyPair.publicKey, relayAddresses: [] })
+    this.record = record
 
     this._refreshing = false
     this._closestNodes = null

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -6,7 +6,7 @@ const Persistent = require('./persistent')
 const { COMMANDS } = require('./constants')
 
 module.exports = class Announcer {
-  constructor (dht, keyPair, target, record) {
+  constructor (dht, keyPair, target, record, opts = {}) {
     this.dht = dht
     this.keyPair = keyPair
     this.target = target
@@ -18,6 +18,8 @@ module.exports = class Announcer {
     this._closestNodes = null
     this._active = null
     this._sleeper = new Sleeper()
+    this._signAnnounce = opts.signAnnounce || Persistent.signAnnounce
+    this._signUnannounce = opts.signUnannounce || Persistent.signUnannounce
 
     this._serverRelays = [
       new Map(),
@@ -144,7 +146,7 @@ module.exports = class Announcer {
 
     if (!token || !from.id || !value) return
 
-    unann.signature = Persistent.signUnannounce(this.target, token, from.id, unann, this.keyPair.secretKey)
+    unann.signature = this._signUnannounce(this.target, token, from.id, unann, this.keyPair.secretKey)
 
     await this.dht.request({
       token,
@@ -164,7 +166,7 @@ module.exports = class Announcer {
       signature: null
     }
 
-    ann.signature = Persistent.signAnnounce(this.target, msg.token, msg.from.id, ann, this.keyPair.secretKey)
+    ann.signature = this._signAnnounce(this.target, msg.token, msg.from.id, ann, this.keyPair.secretKey)
 
     const res = await this.dht.request({
       token: msg.token,

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -6,13 +6,13 @@ const Persistent = require('./persistent')
 const { COMMANDS } = require('./constants')
 
 module.exports = class Announcer {
-  constructor (dht, keyPair, target, record, opts = {}) {
+  constructor (dht, keyPair, target, opts = {}) {
     this.dht = dht
     this.keyPair = keyPair
     this.target = target
     this.relays = []
     this.stopped = false
-    this.record = record
+    this.record = c.encode(m.peer, { publicKey: keyPair.publicKey, relayAddresses: [] })
 
     this._refreshing = false
     this._closestNodes = null
@@ -146,7 +146,7 @@ module.exports = class Announcer {
 
     if (!token || !from.id || !value) return
 
-    unann.signature = this._signUnannounce(this.target, token, from.id, unann, this.keyPair.secretKey)
+    unann.signature = await this._signUnannounce(this.target, token, from.id, unann, this.keyPair.secretKey)
 
     await this.dht.request({
       token,
@@ -166,7 +166,7 @@ module.exports = class Announcer {
       signature: null
     }
 
-    ann.signature = this._signAnnounce(this.target, msg.token, msg.from.id, ann, this.keyPair.secretKey)
+    ann.signature = await this._signAnnounce(this.target, msg.token, msg.from.id, ann, this.keyPair.secretKey)
 
     const res = await this.dht.request({
       token: msg.token,

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -7,7 +7,7 @@ const { FIREWALL, PROTOCOL, ERROR } = require('./constants')
 
 module.exports = function connect (dht, publicKey, opts = {}) {
   const keyPair = opts.keyPair || dht.defaultKeyPair
-  const encryptedSocket = new NoiseSecretStream(true, null, {
+  const encryptedSocket = (opts.secretStream || defaultSecretStream)(true, null, {
     publicKey: keyPair.publicKey,
     remotePublicKey: publicKey,
     autoStart: false
@@ -17,7 +17,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     dht,
     round: 0,
     target: hash(publicKey),
-    handshake: new NoiseWrap(keyPair, publicKey),
+    handshake: (opts.handshake || defaultHandshake)(keyPair, publicKey),
     request: null,
     protocols: PROTOCOL.TCP | PROTOCOL.UTP,
     firewall: FIREWALL.UNKNOWN,
@@ -373,4 +373,12 @@ function hash (data) {
   const out = Buffer.allocUnsafe(32)
   sodium.crypto_generichash(out, data)
   return out
+}
+
+function defaultHandshake (keyPair, remotePublicKey) {
+  return new NoiseWrap(keyPair, remotePublicKey)
+}
+
+function defaultSecretStream (isInitiator, rawStream, opts) {
+  return new NoiseSecretStream(isInitiator, rawStream, opts)
 }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -190,7 +190,7 @@ async function connectThroughNode (c, node) {
     return
   }
 
-  const hs = await c.handshake.final()
+  const hs = c.handshake.final()
 
   c.handshake = null
   c.request = null

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -7,7 +7,7 @@ const { FIREWALL, PROTOCOL, ERROR } = require('./constants')
 
 module.exports = function connect (dht, publicKey, opts = {}) {
   const keyPair = opts.keyPair || dht.defaultKeyPair
-  const encryptedSocket = (opts.secretStream || defaultSecretStream)(true, null, {
+  const encryptedSocket = (opts.createSecretStream || defaultCreateSecretStream)(true, null, {
     publicKey: keyPair.publicKey,
     remotePublicKey: publicKey,
     autoStart: false
@@ -17,7 +17,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     dht,
     round: 0,
     target: hash(publicKey),
-    handshake: (opts.handshake || defaultHandshake)(keyPair, publicKey),
+    handshake: (opts.createHandshake || defaultCreateHandshake)(keyPair, publicKey),
     request: null,
     protocols: PROTOCOL.TCP | PROTOCOL.UTP,
     firewall: FIREWALL.UNKNOWN,
@@ -375,10 +375,10 @@ function hash (data) {
   return out
 }
 
-function defaultHandshake (keyPair, remotePublicKey) {
+function defaultCreateHandshake (keyPair, remotePublicKey) {
   return new NoiseWrap(keyPair, remotePublicKey)
 }
 
-function defaultSecretStream (isInitiator, rawStream, opts) {
+function defaultCreateSecretStream (isInitiator, rawStream, opts) {
   return new NoiseSecretStream(isInitiator, rawStream, opts)
 }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -170,7 +170,7 @@ async function connectThroughNode (c, node) {
     const addr = c.dht._sockets.remoteServerAddress()
 
     c.firewall = c.dht.firewalled ? FIREWALL.UNKNOWN : FIREWALL.OPEN
-    c.request = c.handshake.send({
+    c.request = await c.handshake.send({
       error: ERROR.NONE,
       firewall: c.firewall,
       protocols: c.protocols,
@@ -182,7 +182,7 @@ async function connectThroughNode (c, node) {
   const { serverAddress, clientAddress, relayed, noise } = await c.dht._router.peerHandshake(c.target, { noise: c.request }, node.from)
   if (isDone(c) || c.connect) return
 
-  const payload = c.handshake.recv(noise)
+  const payload = await c.handshake.recv(noise)
   if (!payload) return
 
   if (payload.version !== 1) {
@@ -190,7 +190,7 @@ async function connectThroughNode (c, node) {
     return
   }
 
-  const hs = c.handshake.final()
+  const hs = await c.handshake.final()
 
   c.handshake = null
   c.request = null

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -19,6 +19,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     target: hash(publicKey),
     handshake: (opts.createHandshake || defaultCreateHandshake)(keyPair, publicKey),
     request: null,
+    requesting: false,
     protocols: PROTOCOL.TCP | PROTOCOL.UTP,
     firewall: FIREWALL.UNKNOWN,
     connect: null,
@@ -170,6 +171,7 @@ async function connectThroughNode (c, node) {
     const addr = c.dht._sockets.remoteServerAddress()
 
     c.firewall = c.dht.firewalled ? FIREWALL.UNKNOWN : FIREWALL.OPEN
+    c.requesting = true
     c.request = await c.handshake.send({
       error: ERROR.NONE,
       firewall: c.firewall,
@@ -180,10 +182,10 @@ async function connectThroughNode (c, node) {
   }
 
   const { serverAddress, clientAddress, relayed, noise } = await c.dht._router.peerHandshake(c.target, { noise: c.request }, node.from)
-  if (isDone(c) || c.connect) return
+  if (isDone(c) || c.requesting) return
 
   const payload = await c.handshake.recv(noise)
-  if (!payload) return
+  if (isDone(c) || !payload) return
 
   if (payload.version !== 1) {
     c.encryptedSocket.destroy(new Error('Server is using an incompatible version'))
@@ -194,6 +196,7 @@ async function connectThroughNode (c, node) {
 
   c.handshake = null
   c.request = null
+  c.requesting = false
   c.connect = {
     relayed,
     relayAddress: node.from,

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -179,6 +179,7 @@ async function connectThroughNode (c, node) {
       holepunch: null,
       addresses: addr ? [addr] : []
     })
+    if (isDone(c)) return
   }
 
   const { serverAddress, clientAddress, relayed, noise } = await c.dht._router.peerHandshake(c.target, { noise: c.request }, node.from)

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -166,7 +166,7 @@ async function findAndConnect (c, opts) {
 }
 
 async function connectThroughNode (c, node) {
-  if (!c.request) {
+  if (!c.requesting) {
     // If we have a stable server address, send it over now
     const addr = c.dht._sockets.remoteServerAddress()
 
@@ -182,7 +182,7 @@ async function connectThroughNode (c, node) {
   }
 
   const { serverAddress, clientAddress, relayed, noise } = await c.dht._router.peerHandshake(c.target, { noise: c.request }, node.from)
-  if (isDone(c) || c.requesting) return
+  if (isDone(c) || c.connect) return
 
   const payload = await c.handshake.recv(noise)
   if (isDone(c) || !payload) return

--- a/lib/noise-wrap.js
+++ b/lib/noise-wrap.js
@@ -38,16 +38,16 @@ module.exports = class NoiseWrap {
   final () {
     if (!this.handshake.complete) throw new Error('Handshake did not finish')
 
-    const holepunchCapability = Buffer.allocUnsafe(32)
+    const holepunchSecret = Buffer.allocUnsafe(32)
 
-    sodium.crypto_generichash(holepunchCapability, this.handshake.hash, NS.PEER_HOLEPUNCH)
+    sodium.crypto_generichash(holepunchSecret, this.handshake.hash, NS.PEER_HOLEPUNCH)
 
     return {
       isInitiator: this.isInitiator,
       publicKey: this.keyPair.publicKey,
       remotePublicKey: this.remotePublicKey,
       remoteId: NoiseSecretStream.id(this.handshake.hash, !this.isInitiator),
-      holepunchCapability,
+      holepunchSecret,
       hash: toBuffer(this.handshake.hash),
       rx: toBuffer(this.handshake.rx),
       tx: toBuffer(this.handshake.tx)

--- a/lib/noise-wrap.js
+++ b/lib/noise-wrap.js
@@ -23,14 +23,7 @@ module.exports = class NoiseWrap {
   }
 
   async recv (buf) {
-    let payload = null
-
-    try {
-      payload = c.decode(messages.noisePayload, this.handshake.recv(buf))
-    } catch {
-      return null
-    }
-
+    const payload = c.decode(messages.noisePayload, this.handshake.recv(buf))
     this.remotePublicKey = toBuffer(this.handshake.rs)
     return payload
   }

--- a/lib/noise-wrap.js
+++ b/lib/noise-wrap.js
@@ -35,7 +35,7 @@ module.exports = class NoiseWrap {
     return payload
   }
 
-  async final () {
+  final () {
     if (!this.handshake.complete) throw new Error('Handshake did not finish')
 
     const holepunchCapability = Buffer.allocUnsafe(32)

--- a/lib/noise-wrap.js
+++ b/lib/noise-wrap.js
@@ -17,12 +17,12 @@ module.exports = class NoiseWrap {
     this.handshake.initialise(NOISE_PROLOUGE, remotePublicKey)
   }
 
-  async send (payload) {
+  send (payload) {
     const buf = c.encode(messages.noisePayload, payload)
     return this.handshake.send(buf)
   }
 
-  async recv (buf) {
+  recv (buf) {
     const payload = c.decode(messages.noisePayload, this.handshake.recv(buf))
     this.remotePublicKey = toBuffer(this.handshake.rs)
     return payload

--- a/lib/noise-wrap.js
+++ b/lib/noise-wrap.js
@@ -2,6 +2,7 @@ const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const NoiseHandshake = require('noise-handshake')
 const curve = require('noise-curve-ed')
 const c = require('compact-encoding')
+const sodium = require('sodium-universal')
 const messages = require('./messages')
 const { NS } = require('./constants')
 
@@ -16,12 +17,12 @@ module.exports = class NoiseWrap {
     this.handshake.initialise(NOISE_PROLOUGE, remotePublicKey)
   }
 
-  send (payload) {
+  async send (payload) {
     const buf = c.encode(messages.noisePayload, payload)
     return this.handshake.send(buf)
   }
 
-  recv (buf) {
+  async recv (buf) {
     let payload = null
 
     try {
@@ -34,14 +35,19 @@ module.exports = class NoiseWrap {
     return payload
   }
 
-  final () {
+  async final () {
     if (!this.handshake.complete) throw new Error('Handshake did not finish')
+
+    const holepunchCapability = Buffer.allocUnsafe(32)
+
+    sodium.crypto_generichash(holepunchCapability, this.handshake.hash, NS.PEER_HOLEPUNCH)
 
     return {
       isInitiator: this.isInitiator,
       publicKey: this.keyPair.publicKey,
       remotePublicKey: this.remotePublicKey,
       remoteId: NoiseSecretStream.id(this.handshake.hash, !this.isInitiator),
+      holepunchCapability,
       hash: toBuffer(this.handshake.hash),
       rx: toBuffer(this.handshake.rx),
       tx: toBuffer(this.handshake.tx)

--- a/lib/secure-payload.js
+++ b/lib/secure-payload.js
@@ -1,14 +1,12 @@
 const sodium = require('sodium-universal')
 const { holepunchPayload } = require('./messages')
-const { NS } = require('./constants')
 
 module.exports = class HolepunchPayload {
-  constructor (handshakeHash) {
-    this._sharedSecret = Buffer.allocUnsafe(32)
+  constructor (holepunchCapability) {
+    this._sharedSecret = holepunchCapability
     this._localSecret = Buffer.allocUnsafe(32)
 
     sodium.randombytes_buf(this._localSecret)
-    sodium.crypto_generichash(this._sharedSecret, handshakeHash, NS.PEER_HOLEPUNCH)
   }
 
   decrypt (buffer) {

--- a/lib/secure-payload.js
+++ b/lib/secure-payload.js
@@ -2,8 +2,8 @@ const sodium = require('sodium-universal')
 const { holepunchPayload } = require('./messages')
 
 module.exports = class HolepunchPayload {
-  constructor (holepunchCapability) {
-    this._sharedSecret = holepunchCapability
+  constructor (holepunchSecret) {
+    this._sharedSecret = holepunchSecret
     this._localSecret = Buffer.allocUnsafe(32)
 
     sodium.randombytes_buf(this._localSecret)

--- a/lib/server.js
+++ b/lib/server.js
@@ -74,7 +74,7 @@ module.exports = class Server extends EventEmitter {
 
     this._connects.clear()
 
-    if (this._announcer) await this._announcer.stop()
+    await this._announcer.stop()
     this._announcer = null
 
     this.emit('close')
@@ -89,6 +89,7 @@ module.exports = class Server extends EventEmitter {
     this.target = hash(keyPair.publicKey)
 
     this._keyPair = keyPair
+    this._announcer = new Announcer(this.dht, keyPair, this.target, record, opts)
 
     this.dht._router.set(this.target, {
       relay: null,
@@ -99,16 +100,12 @@ module.exports = class Server extends EventEmitter {
 
     this._listening = true
 
-    if (opts.announce !== false && keyPair.secretKey) {
-      this._announcer = new Announcer(this.dht, keyPair, this.target, record)
-
-      try {
-        await this._announcer.start()
-      } catch (err) {
-        await this._announcer.stop()
-        this._announcer = null
-        throw err
-      }
+    try {
+      await this._announcer.start()
+    } catch (err) {
+      await this._announcer.stop()
+      this._announcer = null
+      throw err
     }
 
     if (this.dht.destroyed) throw new Error('Node destroyed')
@@ -117,36 +114,47 @@ module.exports = class Server extends EventEmitter {
     this.emit('listening')
   }
 
-  async _addHandshake (k, noise, clientAddress, req) {
-    const handshake = this.handshake(this._keyPair, null)
-    const remotePayload = await handshake.recv(noise)
-    const serverAddress = req.to
-
-    if (!remotePayload) return null
-
+  async _addHandshake (k, noise, clientAddress, { to: serverAddress }) {
     let id = this._holepunches.indexOf(null)
     if (id === -1) id = this._holepunches.push(null) - 1
-
-    const fw = this.firewall(handshake.remotePublicKey, remotePayload, clientAddress)
 
     const hs = {
       round: 0,
       reply: null,
       pair: null,
-      protocols: remotePayload.protocols & this._protocols,
-      firewalled: (!fw || !fw.then) ? Promise.resolve(fw) : fw.catch(toTrue),
+      protocols: this._protocols,
+      firewalled: false,
       clearing: null
     }
 
     this._holepunches[id] = hs
 
-    if (await hs.firewalled) {
+    const handshake = this.handshake(this._keyPair, null)
+
+    let remotePayload
+    try {
+      remotePayload = await handshake.recv(noise)
+    } catch (err) {
+      safetyCatch(err)
       this._clearLater(hs, id, k)
       return null
     }
-    if (this.closed) {
+
+    hs.protocols &= remotePayload.protocols
+
+    try {
+      hs.firewalled = await this.firewall(handshake.remotePublicKey, remotePayload, clientAddress)
+    } catch (err) {
+      safetyCatch(err)
+      hs.firewalled = true
+    }
+
+    if (hs.firewalled) {
+      this._clearLater(hs, id, k)
       return null
     }
+
+    if (this.closed) return null
 
     const error = remotePayload.version === 1
       ? hs.protocols === 0 ? ERROR.ABORTED : ERROR.NONE
@@ -159,13 +167,19 @@ module.exports = class Server extends EventEmitter {
     if (ourRemoteAddr) addresses.push(ourRemoteAddr)
     if (ourLocalAddr) addresses.push(ourLocalAddr) // for now always share local addrs, in the future we can do some filtering
 
-    hs.reply = await handshake.send({
-      error,
-      firewall: this.dht.firewalled ? FIREWALL.UNKNOWN : FIREWALL.OPEN,
-      protocols: this._protocols,
-      holepunch: this.dht.firewalled ? { id, relays: this._announcer ? this._announcer.relays : [] } : null,
-      addresses: addresses.length ? addresses : null
-    })
+    try {
+      hs.reply = await handshake.send({
+        error,
+        firewall: this.dht.firewalled ? FIREWALL.UNKNOWN : FIREWALL.OPEN,
+        protocols: this._protocols,
+        holepunch: this.dht.firewalled ? { id, relays: this._announcer.relays } : null,
+        addresses: addresses.length ? addresses : null
+      })
+    } catch (err) {
+      safetyCatch(err)
+      this._clearLater(hs, id, k)
+      return null
+    }
 
     const h = handshake.final()
 
@@ -230,7 +244,6 @@ module.exports = class Server extends EventEmitter {
     const h = await p
     if (!h) return null
 
-    if (await h.firewalled) return null
     if (this.closed) return null
 
     return { socket: h.pair && h.pair.socket, noise: h.reply }
@@ -240,7 +253,6 @@ module.exports = class Server extends EventEmitter {
     const h = id < this._holepunches.length ? this._holepunches[id] : null
     if (!h) return null
 
-    if (await h.firewalled) return null
     if (this.closed) return null
 
     const p = h.pair
@@ -249,7 +261,7 @@ module.exports = class Server extends EventEmitter {
     const remotePayload = p.payload.decrypt(payload)
     if (!remotePayload) return null
 
-    const isServerRelay = this._announcer && this._announcer.isRelay(req.from)
+    const isServerRelay = this._announcer.isRelay(req.from)
     const { error, firewall, round, punching, addresses, remoteAddress, remoteToken } = remotePayload
 
     if (error !== ERROR.NONE) {
@@ -362,11 +374,6 @@ function hasSameAddr (addrs, other) {
     if (addr.port === other.port && addr.host === other.host) return true
   }
   return false
-}
-
-function toTrue (err) {
-  safetyCatch(err)
-  return true
 }
 
 function defaultHandshake (keyPair, remotePublicKey) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,8 +3,6 @@ const safetyCatch = require('safety-catch')
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const NoiseWrap = require('./noise-wrap')
 const sodium = require('sodium-universal')
-const c = require('compact-encoding')
-const m = require('./messages')
 const Announcer = require('./announcer')
 const { FIREWALL, PROTOCOL, ERROR } = require('./constants')
 
@@ -21,8 +19,8 @@ module.exports = class Server extends EventEmitter {
     this.closed = false
     this.firewall = opts.firewall || (() => false)
     this.holepunch = opts.holepunch || (() => true)
-    this.handshake = opts.handshake || defaultHandshake
-    this.secretStream = opts.secretStream || defaultSecretStream
+    this.createHandshake = opts.createHandshake || defaultCreateHandshake
+    this.createSecretStream = opts.createSecretStream || defaultCreateSecretStream
 
     this._protocols = PROTOCOL.TCP | PROTOCOL.UTP
     this._shareLocalAddress = opts.shareLocalAddress !== false
@@ -84,16 +82,14 @@ module.exports = class Server extends EventEmitter {
     if (this._listening) throw new Error('Already listening')
     if (this.dht.destroyed) throw new Error('Node destroyed')
 
-    const record = c.encode(m.peer, { publicKey: keyPair.publicKey, relayAddresses: [] })
-
     this.target = hash(keyPair.publicKey)
 
     this._keyPair = keyPair
-    this._announcer = new Announcer(this.dht, keyPair, this.target, record, opts)
+    this._announcer = new Announcer(this.dht, keyPair, this.target, opts)
 
     this.dht._router.set(this.target, {
       relay: null,
-      record,
+      record: this._announcer.record,
       onpeerhandshake: this._onpeerhandshake.bind(this),
       onpeerholepunch: this._onpeerholepunch.bind(this)
     })
@@ -123,13 +119,13 @@ module.exports = class Server extends EventEmitter {
       reply: null,
       pair: null,
       protocols: this._protocols,
-      firewalled: false,
+      firewalled: true,
       clearing: null
     }
 
     this._holepunches[id] = hs
 
-    const handshake = this.handshake(this._keyPair, null)
+    const handshake = this.createHandshake(this._keyPair, null)
 
     let remotePayload
     try {
@@ -196,7 +192,7 @@ module.exports = class Server extends EventEmitter {
     pair.onconnection = (rawSocket, data, ended, handshake) => {
       this._clearLater(hs, id, k)
 
-      this.onconnection(this.secretStream(false, rawSocket, {
+      this.onconnection(this.createSecretStream(false, rawSocket, {
         handshake,
         data,
         ended
@@ -376,10 +372,10 @@ function hasSameAddr (addrs, other) {
   return false
 }
 
-function defaultHandshake (keyPair, remotePublicKey) {
+function defaultCreateHandshake (keyPair, remotePublicKey) {
   return new NoiseWrap(keyPair, remotePublicKey)
 }
 
-function defaultSecretStream (isInitiator, rawStream, opts) {
+function defaultCreateSecretStream (isInitiator, rawStream, opts) {
   return new NoiseSecretStream(isInitiator, rawStream, opts)
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -38,8 +38,8 @@ module.exports = class Server extends EventEmitter {
     this.emit('connection', encryptedSocket)
   }
 
-  onrawconnection (rawSocket) {
-    this.emit('rawConnection', rawSocket)
+  onrawconnection (rawSocket, data, ended) {
+    this.emit('rawConnection', rawSocket, data, ended)
   }
 
   address () {

--- a/lib/server.js
+++ b/lib/server.js
@@ -162,7 +162,7 @@ module.exports = class Server extends EventEmitter {
       addresses: addresses.length ? addresses : null
     })
 
-    const h = await handshake.final()
+    const h = handshake.final()
 
     if (error !== ERROR.NONE) {
       // TODO: strictly better to clear it later for caching, but whatevs, this is easy

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,6 +19,7 @@ module.exports = class Server extends EventEmitter {
     this.closed = false
     this.firewall = opts.firewall || (() => false)
     this.holepunch = opts.holepunch || (() => true)
+    this.handshake = opts.handshake || ((keyPair) => new NoiseWrap(keyPair, null))
 
     this._protocols = PROTOCOL.TCP | PROTOCOL.UTP
     this._shareLocalAddress = opts.shareLocalAddress !== false
@@ -35,6 +36,10 @@ module.exports = class Server extends EventEmitter {
 
   onconnection (encryptedSocket) {
     this.emit('connection', encryptedSocket)
+  }
+
+  onrawconnection (rawSocket) {
+    this.emit('rawConnection', rawSocket)
   }
 
   address () {
@@ -106,8 +111,9 @@ module.exports = class Server extends EventEmitter {
   }
 
   async _addHandshake (k, noise, clientAddress, req) {
-    const handshake = new NoiseWrap(this._keyPair, null)
-    const remotePayload = handshake.recv(noise)
+    const handshake = this.handshake(this._keyPair)
+    // TODO: verify that this isn't a flooding vector
+    const remotePayload = await handshake.recv(noise)
     const serverAddress = req.to
 
     if (!remotePayload) return null
@@ -148,7 +154,7 @@ module.exports = class Server extends EventEmitter {
     if (ourRemoteAddr) addresses.push(ourRemoteAddr)
     if (ourLocalAddr) addresses.push(ourLocalAddr) // for now always share local addrs, in the future we can do some filtering
 
-    hs.reply = handshake.send({
+    hs.reply = await handshake.send({
       error,
       firewall: this.dht.firewalled ? FIREWALL.UNKNOWN : FIREWALL.OPEN,
       protocols: this._protocols,
@@ -156,7 +162,7 @@ module.exports = class Server extends EventEmitter {
       addresses: addresses.length ? addresses : null
     })
 
-    const h = handshake.final()
+    const h = await handshake.final()
 
     if (error !== ERROR.NONE) {
       // TODO: strictly better to clear it later for caching, but whatevs, this is easy
@@ -171,13 +177,15 @@ module.exports = class Server extends EventEmitter {
     pair.onconnection = (rawSocket, data, ended, handshake) => {
       this._clearLater(hs, id, k)
 
-      const encryptedSocket = new NoiseSecretStream(false, rawSocket, {
-        handshake,
-        data,
-        ended
-      })
-
-      this.onconnection(encryptedSocket)
+      if (handshake.hash) {
+        this.onconnection(new NoiseSecretStream(false, rawSocket, {
+          handshake,
+          data,
+          ended
+        }))
+      } else {
+        this.onrawconnection(rawSocket, data, ended)
+      }
     }
 
     pair.ondestroy = () => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -101,6 +101,7 @@ module.exports = class Server extends EventEmitter {
     } catch (err) {
       await this._announcer.stop()
       this._announcer = null
+      this._listening = false
       throw err
     }
 
@@ -142,7 +143,6 @@ module.exports = class Server extends EventEmitter {
       hs.firewalled = await this.firewall(handshake.remotePublicKey, remotePayload, clientAddress)
     } catch (err) {
       safetyCatch(err)
-      hs.firewalled = true
     }
 
     if (hs.firewalled) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,8 @@ const safetyCatch = require('safety-catch')
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const NoiseWrap = require('./noise-wrap')
 const sodium = require('sodium-universal')
+const c = require('compact-encoding')
+const m = require('./messages')
 const Announcer = require('./announcer')
 const { FIREWALL, PROTOCOL, ERROR } = require('./constants')
 
@@ -27,6 +29,7 @@ module.exports = class Server extends EventEmitter {
     this._announcer = null
     this._connects = new Map()
     this._holepunches = []
+    this._listening = false
     this._closing = null
   }
 
@@ -61,10 +64,10 @@ module.exports = class Server extends EventEmitter {
   async _close () {
     this.closed = true
 
-    if (!this._announcer) return
+    if (!this._listening) return
 
     this.dht.listening.delete(this)
-    this.dht._router.delete(this._announcer.target)
+    this.dht._router.delete(this.target)
 
     while (this._holepunches.length > 0) {
       const h = this._holepunches.pop()
@@ -74,34 +77,43 @@ module.exports = class Server extends EventEmitter {
 
     this._connects.clear()
 
-    await this._announcer.stop()
-    this._announcer = null
+    if (this._announcer) {
+      await this._announcer.stop()
+      this._announcer = null
+    }
 
     this.emit('close')
   }
 
-  async listen (keyPair = this.dht.defaultKeyPair) {
-    if (this._announcer) throw new Error('Already listening')
+  async listen (keyPair = this.dht.defaultKeyPair, opts = {}) {
+    if (this._listening) throw new Error('Already listening')
     if (this.dht.destroyed) throw new Error('Node destroyed')
+
+    const record = c.encode(m.peer, { publicKey: keyPair.publicKey, relayAddresses: [] })
 
     this.target = hash(keyPair.publicKey)
 
     this._keyPair = keyPair
-    this._announcer = new Announcer(this.dht, this._keyPair, this.target)
 
     this.dht._router.set(this.target, {
       relay: null,
-      record: this._announcer.record,
+      record,
       onpeerhandshake: this._onpeerhandshake.bind(this),
       onpeerholepunch: this._onpeerholepunch.bind(this)
     })
 
-    try {
-      await this._announcer.start()
-    } catch (err) {
-      await this._announcer.stop()
-      this._announcer = null
-      throw err
+    this._listening = true
+
+    if (opts.announce !== false && keyPair.secretKey) {
+      this._announcer = new Announcer(this.dht, keyPair, this.target, record)
+
+      try {
+        await this._announcer.start()
+      } catch (err) {
+        await this._announcer.stop()
+        this._announcer = null
+        throw err
+      }
     }
 
     if (this.dht.destroyed) throw new Error('Node destroyed')
@@ -158,7 +170,7 @@ module.exports = class Server extends EventEmitter {
       error,
       firewall: this.dht.firewalled ? FIREWALL.UNKNOWN : FIREWALL.OPEN,
       protocols: this._protocols,
-      holepunch: this.dht.firewalled ? { id, relays: this._announcer.relays } : null,
+      holepunch: this.dht.firewalled ? { id, relays: this._announcer ? this._announcer.relays : [] } : null,
       addresses: addresses.length ? addresses : null
     })
 
@@ -243,7 +255,7 @@ module.exports = class Server extends EventEmitter {
     const remotePayload = p.payload.decrypt(payload)
     if (!remotePayload) return null
 
-    const isServerRelay = this._announcer.isRelay(req.from)
+    const isServerRelay = this._announcer && this._announcer.isRelay(req.from)
     const { error, firewall, round, punching, addresses, remoteAddress, remoteToken } = remotePayload
 
     if (error !== ERROR.NONE) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -74,10 +74,8 @@ module.exports = class Server extends EventEmitter {
 
     this._connects.clear()
 
-    if (this._announcer) {
-      await this._announcer.stop()
-      this._announcer = null
-    }
+    if (this._announcer) await this._announcer.stop()
+    this._announcer = null
 
     this.emit('close')
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -118,7 +118,7 @@ module.exports = class Server extends EventEmitter {
   }
 
   async _addHandshake (k, noise, clientAddress, req) {
-    const handshake = this.handshake(this._keyPair)
+    const handshake = this.handshake(this._keyPair, null)
     const remotePayload = await handshake.recv(noise)
     const serverAddress = req.to
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -124,7 +124,6 @@ module.exports = class Server extends EventEmitter {
 
   async _addHandshake (k, noise, clientAddress, req) {
     const handshake = this.handshake(this._keyPair)
-    // TODO: verify that this isn't a flooding vector
     const remotePayload = await handshake.recv(noise)
     const serverAddress = req.to
 
@@ -144,7 +143,6 @@ module.exports = class Server extends EventEmitter {
       clearing: null
     }
 
-    this._connects.set(k, hs)
     this._holepunches[id] = hs
 
     if (await hs.firewalled) {
@@ -229,12 +227,17 @@ module.exports = class Server extends EventEmitter {
 
   async _onpeerhandshake ({ noise, peerAddress }, req) {
     const k = noise.toString('hex')
-    let h = this._connects.get(k)
 
-    if (!h) {
-      h = await this._addHandshake(k, noise, peerAddress, req)
-      if (!h) return null
+    // The next couple of statements MUST run within the same tick to prevent
+    // a malicious peer from flooding us with handshakes.
+    let p = this._connects.get(k)
+    if (!p) {
+      p = this._addHandshake(k, noise, peerAddress, req)
+      this._connects.set(k, p)
     }
+
+    const h = await p
+    if (!h) return null
 
     if (await h.firewalled) return null
     if (this.closed) return null

--- a/lib/server.js
+++ b/lib/server.js
@@ -21,7 +21,8 @@ module.exports = class Server extends EventEmitter {
     this.closed = false
     this.firewall = opts.firewall || (() => false)
     this.holepunch = opts.holepunch || (() => true)
-    this.handshake = opts.handshake || ((keyPair) => new NoiseWrap(keyPair, null))
+    this.handshake = opts.handshake || defaultHandshake
+    this.secretStream = opts.secretStream || defaultSecretStream
 
     this._protocols = PROTOCOL.TCP | PROTOCOL.UTP
     this._shareLocalAddress = opts.shareLocalAddress !== false
@@ -39,10 +40,6 @@ module.exports = class Server extends EventEmitter {
 
   onconnection (encryptedSocket) {
     this.emit('connection', encryptedSocket)
-  }
-
-  onrawconnection (rawSocket, data, ended) {
-    this.emit('rawConnection', rawSocket, data, ended)
   }
 
   address () {
@@ -187,15 +184,11 @@ module.exports = class Server extends EventEmitter {
     pair.onconnection = (rawSocket, data, ended, handshake) => {
       this._clearLater(hs, id, k)
 
-      if (handshake.hash) {
-        this.onconnection(new NoiseSecretStream(false, rawSocket, {
-          handshake,
-          data,
-          ended
-        }))
-      } else {
-        this.onrawconnection(rawSocket, data, ended)
-      }
+      this.onconnection(this.secretStream(false, rawSocket, {
+        handshake,
+        data,
+        ended
+      }))
     }
 
     pair.ondestroy = () => {
@@ -376,4 +369,12 @@ function hasSameAddr (addrs, other) {
 function toTrue (err) {
   safetyCatch(err)
   return true
+}
+
+function defaultHandshake (keyPair, remotePublicKey) {
+  return new NoiseWrap(keyPair, remotePublicKey)
+}
+
+function defaultSecretStream (isInitiator, rawStream, opts) {
+  return new NoiseSecretStream(isInitiator, rawStream, opts)
 }

--- a/lib/socket-pairer.js
+++ b/lib/socket-pairer.js
@@ -65,7 +65,7 @@ class Pair {
     const self = this
     const dht = this._sockets.dht
 
-    this.payload = new Payload(this.handshake.holepunchCapability)
+    this.payload = new Payload(this.handshake.holepunchSecret)
 
     this._sleeper = new Sleeper()
     this._onmessagebound = onmessage

--- a/lib/socket-pairer.js
+++ b/lib/socket-pairer.js
@@ -65,7 +65,7 @@ class Pair {
     const self = this
     const dht = this._sockets.dht
 
-    this.payload = new Payload(this.handshake.hash)
+    this.payload = new Payload(this.handshake.holepunchCapability)
 
     this._sleeper = new Sleeper()
     this._onmessagebound = onmessage

--- a/test/noncustodial.js
+++ b/test/noncustodial.js
@@ -1,0 +1,69 @@
+const test = require('brittle')
+const NoiseSecretStream = require('@hyperswarm/secret-stream')
+const { swarm } = require('./helpers')
+const DHT = require('../')
+const NoiseWrap = require('../lib/noise-wrap')
+
+const keyPair = DHT.keyPair()
+
+test('createServer() with externally managed secret key', async (t) => {
+  const [a, b] = await swarm(t)
+
+  const lc = t.test('socket lifecycle')
+  lc.plan(3)
+
+  const handshake = new NoiseWrap(keyPair, null)
+
+  const server = a.createServer({
+    handshake: () => {
+      return {
+        send (payload) {
+          return handshake.send(payload)
+        },
+        recv (buffer) {
+          return handshake.recv(buffer)
+        },
+        final () {
+          return {
+            ...handshake.final(),
+
+            // Remove the Noise keys as these are kept secret
+            hash: null,
+            rx: null,
+            tx: null
+          }
+        }
+      }
+    }
+  })
+
+  server.on('rawConnection', (rawSocket, data, ended) => {
+    lc.pass('server side opened')
+
+    const socket = new NoiseSecretStream(false, rawSocket, {
+      handshake: handshake.final(),
+      data,
+      ended
+    })
+
+    socket
+      .on('data', (data) => lc.alike(data, Buffer.from('hello')))
+      .once('end', () => {
+        lc.pass('server side ended')
+        socket.end()
+      })
+  })
+
+  // Only pass the public key to the server which will prevent it from
+  // announcing itself
+  await server.listen({ publicKey: keyPair.publicKey })
+
+  // Manually announce the server to the DHT to make it discoverable
+  await a.announce(server.target, keyPair).finished()
+
+  b.connect(server.publicKey).end('hello')
+
+  await lc
+
+  await server.close()
+})

--- a/test/noncustodial.js
+++ b/test/noncustodial.js
@@ -14,8 +14,8 @@ test('createServer + connect - external secret key', async (t) => {
   const serverKeyPair = DHT.keyPair()
 
   const server = a.createServer({
-    handshake: handshake(serverKeyPair),
-    secretStream
+    createHandshake: createHandshake(serverKeyPair),
+    createSecretStream
   })
 
   server.on('connection', (socket) => {
@@ -40,8 +40,8 @@ test('createServer + connect - external secret key', async (t) => {
   const clientKeyPair = DHT.keyPair()
 
   const client = b.connect(server.publicKey, {
-    handshake: handshake(clientKeyPair),
-    secretStream,
+    createHandshake: createHandshake(clientKeyPair),
+    createSecretStream,
 
     // Only pass the public key to the client
     keyPair: { publicKey: clientKeyPair.publicKey }
@@ -58,7 +58,7 @@ test('createServer + connect - external secret key', async (t) => {
 // secret stream, and sign announces/unannounces without any sensitive data
 // being exposed to the relaying DHT node.
 
-function handshake (keyPair) {
+function createHandshake (keyPair) {
   return (_, remotePublicKey) => new class extends NoiseWrap {
     final () {
       const { hash, rx, tx, ...rest } = super.final()
@@ -73,7 +73,7 @@ function handshake (keyPair) {
   }(keyPair, remotePublicKey)
 }
 
-function secretStream (isInitiator, rawSocket, opts) {
+function createSecretStream (isInitiator, rawSocket, opts) {
   if (opts.handshake) {
     const { $secret, ...rest } = opts.handshake
     opts = { ...opts, handshake: { ...rest, ...$secret } }


### PR DESCRIPTION
This pull request introduces support for externally managed secret keys to allow a relaying DHT node to act on behalf of another relayed node. A summary of the changes:

- `DHT.createServer()` and `DHT.connect()` now accept two new options, `createHandshake` and `createSecretStream`, to allow callers to perform Noise handshaking and stream setup themselves. To ensure that the relaying DHT node can still hole punch on behalf of the relayed node, `handshake.final()` is now required to return a `holepunchSecret` key, but may leave out the Noise keys.

- `server.listen()` now accepts two new options, `signAnnounce` and `signUnannounce`, to allow callers to perform signing themselves.

- `DHT.lookupAndUnannounce()`, `DHT.unannounce()`, and `DHT.announce()` now accept a new option, `signUnannounce`, to allow callers to perform signing themselves. `DHT.announce()` also accepts a `signAnnounce` option and `DHT.mutablePut()` accepts a `signMutable` option.