### PR TITLE
Add browser.js to avoid nodejs dependencies

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,18 @@
+const sodium = require('sodium-universal')
+const Buffer = require('b4a')
+
+module.exports = class DHT {
+  constructor () {
+    throw new Error(
+      'Cannot use DHT in a browser context, use a dht-relay instead'
+    )
+  }
+
+  static keyPair (seed) {
+    const publicKey = Buffer.alloc(32)
+    const secretKey = Buffer.alloc(64)
+    if (seed) sodium.crypto_sign_seed_keypair(publicKey, secretKey, seed)
+    else sodium.crypto_sign_keypair(publicKey, secretKey)
+    return { publicKey, secretKey }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const DHT = require('dht-rpc')
+const Buffer = require('b4a')
 const sodium = require('sodium-universal')
 const { dual } = require('bind-easy')
 const c = require('compact-encoding')

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "5.0.12",
   "description": "The DHT powering the HyperSwarm stack",
   "main": "index.js",
+  "browser": "browser.js",
   "dependencies": {
     "@hyperswarm/secret-stream": "^5.1.0",
+    "b4a": "^1.3.1",
     "bind-easy": "^1.0.1",
     "bogon": "^1.0.0",
     "compact-encoding": "^2.4.1",


### PR DESCRIPTION
Added dependency: `b4a`
Could have refactored `createKeyPair` to be shared between`index.js` and `browser.js` but I wanted to keep changes to `index.js` minimal.