### PR TITLE
Failing test: manually adding nodes with no bootstrap

### DIFF
--- a/test/announces.js
+++ b/test/announces.js
@@ -67,6 +67,59 @@ test('announce to group and lookup', async function (t) {
   }
 })
 
+test('announce to group and lookup (manual addNode)', async function (t) {
+  // Swarm with no bootstrap
+  const nodes = await swarm(t, 32, [])
+  await Promise.all(nodes.map(n => n.ready()))
+
+  // Manually add all nodes in swarm to each other
+  for (const node of nodes) {
+    for (const otherNode of nodes) {
+      if (node === otherNode) continue
+      const { address: host, port } = otherNode.address()
+      node.addNode({ host, port })
+    }
+  }
+
+  const [a, b] = nodes
+  const keyPair1 = DHT.keyPair()
+  const keyPair2 = DHT.keyPair()
+  const target = DHT.hash(Buffer.from('testing...'))
+
+  await a.announce(target, keyPair1, []).finished()
+
+  {
+    const result = await toArray(b.lookup(target))
+    t.ok(result.length > 0, 'has at least one result')
+    t.alike(result[0].peers.length, 1, 'one peer')
+    t.alike(result[0].peers[0].publicKey, keyPair1.publicKey)
+  }
+
+  await a.announce(target, keyPair2, [{ host: '1.2.3.4', port: 1234 }]).finished()
+
+  {
+    const result = await toArray(b.lookup(target))
+    t.ok(result.length > 0, 'has at least one result')
+    t.alike(result[0].peers.length, 2, 'two peers')
+    t.alike([result[0].peers[0].publicKey, result[0].peers[1].publicKey].sort(), [keyPair1.publicKey, keyPair2.publicKey].sort())
+
+    const latest = result[0].peers[result[0].peers[0].publicKey.equals(keyPair2.publicKey) ? 0 : 1]
+
+    t.is(latest.relayAddresses.length, 1, 'announced one relay')
+    t.alike(latest.relayAddresses[0], { host: '1.2.3.4', port: 1234 })
+  }
+
+  for await (const data of a.findPeer(keyPair1.publicKey)) {
+    t.fail('peer should not be announced')
+    t.absent(data, 'just make standard happy')
+  }
+
+  for await (const data of a.findPeer(keyPair2.publicKey)) {
+    t.fail('peer should not be announced')
+    t.absent(data, 'just make standard happy')
+  }
+})
+
 test('announce null relay addresses', async function (t) {
   const [a] = await swarm(t)
   const keyPair = DHT.keyPair()


### PR DESCRIPTION
As far as I understand the docs, it should be possible to create a swarm by creating each node without any bootstrap nodes, and then manually adding each node to the routing table. However, this fails with the error:

```
Error: Too few nodes responded
    at Query._endAfterCommit (./node_modules/dht-rpc/lib/query.js:195:20)
    at Query._flush (./node_modules/dht-rpc/lib/query.js:190:10)
    at Query._readMore (./node_modules/dht-rpc/lib/query.js:175:12)
    at Query._onvisit (./node_modules/dht-rpc/lib/query.js:255:12)
    at IO.onmessage (./node_modules/dht-rpc/lib/io.js:77:13)
    at Socket.emit (node:events:390:28)
    at UDP.onMessage [as onmessage] (node:dgram:939:8)
Emitted 'error' event on Query instance at:
    at ReadableState.afterDestroy (./node_modules/streamx/index.js:442:19)
    at Query._destroy (./node_modules/streamx/index.js:535:5)
    at ReadableState.updateNonPrimary (./node_modules/streamx/index.js:349:16)
    at ReadableState.update (./node_modules/streamx/index.js:333:69)
    at ReadableState.updateReadNT (./node_modules/streamx/index.js:477:8)
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
```

This is a failing test for that issue.