### PR TITLE
fix: fix address undefined error

### DIFF
--- a/lib/socket-pairer.js
+++ b/lib/socket-pairer.js
@@ -427,6 +427,10 @@ class Pair {
 
     if (!address) address = from
 
+    // If `from` is null, and `addr.host` is private or bogon, then `address`
+    // will be undefined here, so the next line will throw an error.
+    if (!address) return
+
     // TODO: if this is a common mistake that two lan computers can have dual IPs we should make this better
     // like, do some stuff to check the range of the remote host and ours and if they overlap
     const sameNetwork = address.host === this._sockets.dht.host || address.host === to.host


### PR DESCRIPTION
I came across this error when creating a DHT on a local network. If `addr.host` is a private or bogon address, then `address` can end up being null (because for some reason `reply` is `null` the first time that `connect()` is called), which results in an uncaught error.