### PR TITLE
Lock down IP object shapes

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,9 +1,30 @@
 const c = require('compact-encoding')
 const net = require('compact-encoding-net')
 
-const ipv4 = net.ipv4Address
+const ipv4 = {
+  ...net.ipv4Address,
+  decode (state) {
+    const ip = net.ipv4Address.decode(state)
+    return {
+      host: ip.host,
+      port: ip.port
+    }
+  }
+}
+
 const ipv4Array = c.array(ipv4)
-const ipv6 = net.ipv6Address
+
+const ipv6 = {
+  ...net.ipv6Address,
+  decode (state) {
+    const ip = net.ipv6Address.decode(state)
+    return {
+      host: ip.host,
+      port: ip.port
+    }
+  }
+}
+
 const ipv6Array = c.array(ipv6)
 
 exports.handshake = {


### PR DESCRIPTION
As the DHT keeps IPv4 and IPv6 addresses separate, the `family` property introduced in https://github.com/compact-encoding/compact-encoding-net/pull/1 isn't needed for distinguishing them.